### PR TITLE
Add error displaying for posts, error and text can't be empty.

### DIFF
--- a/content/style.css
+++ b/content/style.css
@@ -49,6 +49,12 @@ main {
   margin: 20px auto;
 }
 
+.error-box {
+    border: red 2px solid;
+    padding: 10px;
+    width: fit-content;
+}
+
 .news-item {
   position: relative;
   border-bottom: 1px solid #555;

--- a/server/page/new_page.go
+++ b/server/page/new_page.go
@@ -7,9 +7,11 @@ import (
 	"html/template"
 	"log"
 	"net/http"
+	"strings"
 )
+
 func MakeAddPostHandler(ses *session.Sessions, strg *storage.Storage) http.HandlerFunc {
-	return func (w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
 		AddPostHandler(w, r, ses, strg)
 	}
 }
@@ -28,8 +30,8 @@ func AddPostHandler(w http.ResponseWriter, r *http.Request, ses *session.Session
 
 func addPostPage(ses *session.Sessions, w http.ResponseWriter, r *http.Request, status string) {
 	page := tmpl.PageBase[struct{ AddPostError string }]{
-		PageName:   "addpost",
-		Content:    struct{ AddPostError string }{status},
+		PageName: "addpost",
+		Content:  struct{ AddPostError string }{status},
 	}
 
 	sessionCookie, err := r.Cookie(session.SessionCookie)
@@ -66,6 +68,12 @@ func addPostAction(ses *session.Sessions, strg *storage.Storage, w http.Response
 
 	title := r.FormValue("title")
 	text := r.FormValue("text")
+
+	if strings.TrimSpace(title) == "" || strings.TrimSpace(text) == "" {
+		log.Println("Error while adding post: title or text are empty")
+		addPostPage(ses, w, r, "Please make sure both the title and text include at least one letter and aren't just empty.")
+		return
+	}
 
 	err = strg.AddPost(username, title, text)
 

--- a/server/page/user_content.go
+++ b/server/page/user_content.go
@@ -1,16 +1,18 @@
 package page
 
 import (
+	"fmt"
 	"forumapp/session"
 	"forumapp/storage"
 	"forumapp/tmpl"
 	"html/template"
 	"log"
 	"net/http"
+	"strings"
 )
 
 func MakeUserContent(ses *session.Sessions, strg *storage.Storage) http.HandlerFunc {
-	return func (w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
 		UserContent(w, r, ses, strg)
 	}
 }
@@ -24,9 +26,9 @@ func UserContent(w http.ResponseWriter, r *http.Request, ses *session.Sessions, 
 		return
 	}
 
-	switch (resourceType) {
+	switch resourceType {
 	case storage.POST_RESOURCE:
-		renderPost(ses, strg, r.URL.Path, w, r)
+		renderPost(ses, strg, r.URL.Path, "", w, r)
 	case storage.COMMENT_RESOURCE:
 		// TODO: render standalone comments with replies (direct link to comment)
 		// renderComment(resourcePath, user, w)
@@ -37,8 +39,7 @@ func UserContent(w http.ResponseWriter, r *http.Request, ses *session.Sessions, 
 	}
 }
 
-
-func renderPost(ses *session.Sessions, strg *storage.Storage, uri string, w http.ResponseWriter, r *http.Request) {
+func renderPost(ses *session.Sessions, strg *storage.Storage, uri string, status string, w http.ResponseWriter, r *http.Request) {
 	var page tmpl.PostPage[tmpl.TextPost]
 
 	sessionCookie, err := r.Cookie(session.SessionCookie)
@@ -46,12 +47,12 @@ func renderPost(ses *session.Sessions, strg *storage.Storage, uri string, w http
 		page.Username, page.IsLoggedIn = ses.CheckAuth(sessionCookie.Value)
 	}
 
-	content, err := strg.GetPost(r.URL.Path)
+	content, err := strg.GetPost(uri)
 	if err != nil {
 		log.Println("\"post\" page generation failed:", err)
 	}
-
-    page.Content = content
+	content.TextPostError = status
+	page.Content = content
 
 	fns := template.FuncMap{
 		"indent": func(comments []tmpl.Comment) []tmpl.Comment {
@@ -76,29 +77,38 @@ func renderPost(ses *session.Sessions, strg *storage.Storage, uri string, w http
 }
 
 func MakeCommentAction(ses *session.Sessions, strg *storage.Storage) http.HandlerFunc {
-	return func (w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
 		CommentAction(w, r, ses, strg)
 	}
 }
 
 func CommentAction(w http.ResponseWriter, r *http.Request, ses *session.Sessions, strg *storage.Storage) {
+	location := r.FormValue("location")
+	text := r.FormValue("comment")
+
 	sessionCookie, err := r.Cookie(session.SessionCookie)
 	if err != nil {
-		w.Write([]byte("Error: auth failed"))
+		log.Println("Error: auth failed")
+		renderPost(ses, strg, location, "auth failed", w, r)
 		return
 	}
 	username, isLoggedIn := ses.CheckAuth(sessionCookie.Value)
 	if !isLoggedIn {
-		w.Write([]byte("Error: not logged in"))
+		log.Println("Error: not logged in")
+		renderPost(ses, strg, location, "not logged in", w, r)
 		return
 	}
 
-	location := r.FormValue("location")
-	text := r.FormValue("comment")
+	if strings.TrimSpace(text) == "" {
+		log.Println("Error while adding comment: text is empty")
+		renderPost(ses, strg, location, "Please make sure the text include at least one letter and isn't just empty.", w, r)
+		return
+	}
 
 	err = strg.AddComment(username, text, location)
 	if err != nil {
-		w.Write([]byte("error: " + err.Error()))
+		log.Println("Error: ", err)
+		renderPost(ses, strg, location, fmt.Sprint("Error: ", err), w, r)
 		return
 	}
 

--- a/server/tmpl/tmpl.go
+++ b/server/tmpl/tmpl.go
@@ -47,12 +47,13 @@ type (
 
 	// Matches textpost.template
 	TextPost struct {
-		Location     string
-		Title        string
-		Text         string
-		Author       string
-		CreationDate string
-		Comments     []Comment
+		Location      string
+		Title         string
+		Text          string
+		Author        string
+		CreationDate  string
+		TextPostError string
+		Comments      []Comment
 	}
 
 	PostType interface {

--- a/templates/addpost.template
+++ b/templates/addpost.template
@@ -15,12 +15,6 @@
       width: 85%;
     }
 
-    .error {
-      border: red 2px solid;
-      margin: 20p;
-      padding: 10px;
-    }
-
     .success {
       border: green 2px solid;
       margin: 20p;
@@ -30,9 +24,11 @@
   <form action="/addpost" method="post">
 
     {{ if not (eq .AddPostError "") }}
-    <label class="error">
-      Error: {{ .AddPostError }}
-    </label>
+    <div class="error-box">
+      <label>
+        Error: {{ .AddPostError }}
+      </label>
+    </div>
     <br><br>
     {{ end }}
 

--- a/templates/textpost.template
+++ b/templates/textpost.template
@@ -1,4 +1,13 @@
 {{define "pagecontent"}}
+  {{ if not (eq .TextPostError "") }}
+    <div class="error-box">
+      <label>
+        Error: {{ .TextPostError }}
+      </label>
+    </div>
+    <br><br>
+  {{ end }}
+
   <div class="news-item">
     <h2><a href="#">{{ .Title }}</a></h2>
     <p class="metadata creation-date">{{ .CreationDate }}</p>


### PR DESCRIPTION
As in title

Things I did:
- Displaying error at the top of post page
- Better error displaying for comment section
- Change to use div error-box class instead of label class, more responsive approach
- Gofmt

![Screenshot From 2025-04-27 14-56-11](https://github.com/user-attachments/assets/ebc7c356-6311-41b5-b025-0101bd86ed88)
